### PR TITLE
Additional feature toggles

### DIFF
--- a/nais/nais-preprod.yml
+++ b/nais/nais-preprod.yml
@@ -109,6 +109,10 @@ spec:
       value: "false"
     - name: SEND_TO_SOKNADSFILLAGER
       value: "false"
+    - name: USE_REAL_ENDPOINT_IN_SOKNADSMOTTAKER
+      value: "false"
+    - name: USE_REAL_ENDPOINT_IN_SOKNADSFILLAGER
+      value: "false"
     - name: SERVLET_CONTEXT_PATH
       value: {{contextPath}}
     - name: SOKNAD_FSS_PROXY_SCOPE

--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -110,6 +110,10 @@ spec:
       value: "false"
     - name: SEND_TO_SOKNADSFILLAGER
       value: "false"
+    - name: USE_REAL_ENDPOINT_IN_SOKNADSMOTTAKER
+      value: "false"
+    - name: USE_REAL_ENDPOINT_IN_SOKNADSFILLAGER
+      value: "false"
     - name: SERVLET_CONTEXT_PATH
       value: {{contextPath}}
     - name: SOKNAD_FSS_PROXY_SCOPE

--- a/sendsoknad-boot/src/main/resources/application.yaml
+++ b/sendsoknad-boot/src/main/resources/application.yaml
@@ -125,7 +125,9 @@ systemuser:
         password: ${PERSONINFORMASJON_PASSWORD}
 innsending:
     sendDirectlyToSoknadsmottaker: ${SEND_DIRECTLY_TO_SOKNADSMOTTAKER}
+    useRealEndpointInSoknadsmottaker: ${USE_REAL_ENDPOINT_IN_SOKNADSMOTTAKER}
     sendToSoknadsfillager: ${SEND_TO_SOKNADSFILLAGER}
+    useRealEndpointInSoknadsfillager: ${USE_REAL_ENDPOINT_IN_SOKNADSFILLAGER}
     soknadsfillager:
         host: ${SOKNADSFILLAGER_HOST}
         username: ${INNSENDING_USERNAME}

--- a/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/SoknadDataFletterIntegrationTestContext.java
+++ b/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/SoknadDataFletterIntegrationTestContext.java
@@ -53,7 +53,7 @@ public class SoknadDataFletterIntegrationTestContext {
         return new SoknadDataFletter(context, null, null, null, null,
                 null, null, null, null, null,
                 null, null, null, null, null,
-                "true", "true");
+                "true", "true", "true");
     }
 
     @Bean

--- a/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/SoknadDataFletterTest.java
+++ b/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/SoknadDataFletterTest.java
@@ -191,7 +191,7 @@ public class SoknadDataFletterTest {
 
         verify(filestorage, times(2)).store(eq(behandlingsId), any());
         verify(innsendingService, times(1)).sendSoknad(any(), any(), any(), any(), any(), any());
-        verify(legacyInnsendingService, times(1 /*TODO: Change to 0*/)).sendSoknad(any(), any(), any(), any(), any());
+        verify(legacyInnsendingService, times(0)).sendSoknad(any(), any(), any(), any(), any());
         verify(hendelseRepository, times(1)).hentVersjon(eq(behandlingsId));
         verify(soknadMetricsService, times(1)).sendtSoknad(eq(AAP), eq(false));
     }

--- a/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/SoknadServiceIntegrasjonsTest.java
+++ b/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/SoknadServiceIntegrasjonsTest.java
@@ -87,7 +87,7 @@ public class SoknadServiceIntegrasjonsTest {
                 fillagerService, vedleggFraHenvendelsePopulator, faktaService, lokalDb, hendelseRepository, config,
                 new AlternativRepresentasjonService(config, tekstHenter), soknadMetricsService, skjemaOppslagService,
                 legacyInnsendingService, innsendingService, filestorage, null,
-                "true", "true");
+                "true", "true", "true");
 
         soknadService = new SoknadService(lokalDb, henvendelseService, null, fillagerService, null,
                 soknadDataFletter, soknadMetricsService);

--- a/sendsoknad-innsending/src/main/kotlin/no/nav/sbl/soknadinnsending/config/InnsendingSpringConfig.kt
+++ b/sendsoknad-innsending/src/main/kotlin/no/nav/sbl/soknadinnsending/config/InnsendingSpringConfig.kt
@@ -17,21 +17,24 @@ open class InnsendingSpringConfig {
 	open fun innsending(
 		@Value("\${innsending.soknadsmottaker.host}") host: String,
 		@Value("\${innsending.soknadsmottaker.username}") username: String,
-		@Value("\${innsending.soknadsmottaker.password}") password: String
-	): Innsending = InnsendingImpl(host, username, password)
+		@Value("\${innsending.soknadsmottaker.password}") password: String,
+		@Value("\${innsending.useRealEndpointInSoknadsmottaker}") useRealEndpoint: Boolean
+	): Innsending = InnsendingImpl(host, username, password, useRealEndpoint)
 
 	@Bean
 	open fun filestorage(
 		@Value("\${innsending.soknadsfillager.host}") host: String,
 		@Value("\${innsending.soknadsfillager.username}") username: String,
-		@Value("\${innsending.soknadsfillager.password}") password: String
-	): Filestorage = FilestorageService(host, username, password)
+		@Value("\${innsending.soknadsfillager.password}") password: String,
+		@Value("\${innsending.useRealEndpointInSoknadsfillager}") useRealEndpoint: Boolean
+	): Filestorage = FilestorageService(host, username, password, useRealEndpoint)
 
 	@Bean
 	open fun brukernotifikasjon(
 		@Value("\${innsending.soknadsmottaker.host}") host: String,
 		@Value("\${innsending.soknadsmottaker.username}") username: String,
 		@Value("\${innsending.soknadsmottaker.password}") password: String,
-		@Value("\${innsending.brukernotifikasjon.host}") brukernotifikasjonIngress: String
-	): Brukernotifikasjon = BrukernotifikasjonService(host, username, password, brukernotifikasjonIngress)
+		@Value("\${innsending.brukernotifikasjon.host}") brukernotifikasjonIngress: String,
+		@Value("\${innsending.useRealEndpointInSoknadsmottaker}") useRealEndpoint: Boolean
+	): Brukernotifikasjon = BrukernotifikasjonService(host, username, password, brukernotifikasjonIngress, useRealEndpoint)
 }

--- a/sendsoknad-innsending/src/main/kotlin/no/nav/sbl/soknadinnsending/innsending/InnsendingImpl.kt
+++ b/sendsoknad-innsending/src/main/kotlin/no/nav/sbl/soknadinnsending/innsending/InnsendingImpl.kt
@@ -13,7 +13,8 @@ import org.springframework.beans.factory.annotation.Value
 class InnsendingImpl(
 	@Value("\${innsending.soknadsmottaker.host}") host: String,
 	@Value("\${innsending.soknadsmottaker.username}") username: String,
-	@Value("\${innsending.soknadsmottaker.password}") password: String
+	@Value("\${innsending.soknadsmottaker.password}") password: String,
+	@Value("\${innsending.useRealEndpointInSoknadsmottaker}") private val useRealEndpoint: Boolean
 ) : Innsending {
 	private val logger = LoggerFactory.getLogger(javaClass)
 	private val soknadApi: SoknadApi
@@ -24,7 +25,7 @@ class InnsendingImpl(
 		ApiClient.password = password
 		soknadApi = SoknadApi(host)
 
-		logger.info("Config for Soknadsmottaker. Username: $username, password: ${password[0]}, host: $host")
+		logger.info("Config for Soknadsmottaker. Username: $username, password: ${password[0]}, host: $host, useRealEndpoint: $useRealEndpoint")
 	}
 
 	override fun sendInn(
@@ -35,6 +36,9 @@ class InnsendingImpl(
 		val soknad = createSoknad(soknadsdata, vedleggsdata, hovedskjemas)
 		logger.info("${soknad.innsendingId}: Sending in Soknad to Soknadsmottaker")
 
-		soknadApi.receiveTest(soknad, soknad.innsendingId, "sendsoknad") // TODO: Change to soknadApi.receive(soknad)
+		if (useRealEndpoint)
+			soknadApi.receive(soknad)
+		else
+			soknadApi.receiveTest(soknad, soknad.innsendingId, "sendsoknad")
 	}
 }

--- a/sendsoknad-web/src/test/resources/environment-test.properties
+++ b/sendsoknad-web/src/test/resources/environment-test.properties
@@ -138,4 +138,6 @@ innsending.soknadsfillager.username=testusername
 innsending.soknadsfillager.password=testpassword
 innsending.sendDirectlyToSoknadsmottaker=true
 innsending.sendToSoknadsfillager=true
+innsending.useRealEndpointInSoknadsmottaker=true
+innsending.useRealEndpointInSoknadsfillager=true
 innsending.brukernotifikasjon.host=localhost:12524


### PR DESCRIPTION
I think two sets of feature toggles are useful. One to specify if we should send to Soknadsmottaker/Soknadsfillager at all, and one to specify if we are to send to the real endpoint or the test endpoint.

* If both are false, we send through Henvendelse, the old way.
* If `SEND_TO_SOKNADSFILLAGER` is true but `USE_REAL_ENDPOINT_IN_SOKNADSFILLAGER` is false, we send through Henvendelse, the old way. We also send the new way, but to the test endpoints. This way, we can test connection and OAuth, without actually sending anything. If Exceptions happen, they will be caught and the user will have their Soknad sent in via Henvendelse still.
* If both are true, then we send the new way and no longer send via Henvendelse.