### PR TITLE
Fjern skjemanummerTillegg i vedleggstittel

### DIFF
--- a/sendsoknad-business/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/InnsendingDataMappers.java
+++ b/sendsoknad-business/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/InnsendingDataMappers.java
@@ -149,14 +149,9 @@ class InnsendingDataMappers {
         if ("N6".equalsIgnoreCase(vedlegg.getSkjemaNummer()) && vedleggName != null && !"".equals(vedleggName)) {
             return vedleggName;
         }
-        String skjemanummerTillegg = "";
-        if (vedlegg.getSkjemanummerTillegg() != null && !"".equals(vedlegg.getSkjemanummerTillegg())) {
-            skjemanummerTillegg = ": " + vedlegg.getSkjemanummerTillegg();
-        }
 
         try {
-            String skjemaNavn = SkjemaOppslagService.getTittel(vedlegg.getSkjemaNummer());
-            return skjemaNavn + skjemanummerTillegg;
+            return SkjemaOppslagService.getTittel(vedlegg.getSkjemaNummer());
 
         } catch (Exception e) {
             logger.warn("{}: Unable to find tittel for '{}'", behandlingsId, vedlegg.getSkjemaNummer());

--- a/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/InnsendingDataMappersTest.java
+++ b/sendsoknad-business/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/business/service/soknadservice/InnsendingDataMappersTest.java
@@ -192,7 +192,7 @@ public class InnsendingDataMappersTest {
         assertVedleggsdata(new Vedleggsdata("N6 with name", DEFAULT_VEDLEGG_MIMETYPE, "PDF", vedleggNavn, "N6", vedleggNavn), vedleggsdata.get(0));
         assertVedleggsdata(new Vedleggsdata("N6 with name = null, skjemanummerTillegg = null", "application/json", "JSON", "jollyjson.json", "N6", N6_TITTEL), vedleggsdata.get(1));
         assertVedleggsdata(new Vedleggsdata("N6 with blank name, blank skjemanummerTillegg", DEFAULT_VEDLEGG_MIMETYPE, "PDF", DEFAULT_VEDLEGG_NAME, "N6", N6_TITTEL), vedleggsdata.get(2));
-        assertVedleggsdata(new Vedleggsdata("L8", DEFAULT_VEDLEGG_MIMETYPE, "PDF", "L8", "L8", L8_TITTEL + ": Apa Bepa"), vedleggsdata.get(3));
+        assertVedleggsdata(new Vedleggsdata("L8", DEFAULT_VEDLEGG_MIMETYPE, "PDF", "L8", "L8", L8_TITTEL), vedleggsdata.get(3));
     }
 
     @Test


### PR DESCRIPTION
## Beskrivelse

Feil i vedleggstittel for søknad om [tilleggsstønad](https://soknad.dev.nav.no/soknadtilleggsstonader).
Det legges ved skjemanummer tillegg i dag på tittelen som ser rart ut. Denne PR'en fjerner dette.

Har testet i dev at det fungerer (se screenshot under)

## Dod
Tekster på vedlegg i GOSYS og JOARK er lik det som vises i kvitteringen.

## Screenshots
### Før
![image](https://user-images.githubusercontent.com/7783861/220627918-01a773d1-a35b-4d80-8a46-dc69fdd5f781.png)

### Etter
![Skjermbilde 2023-02-22 kl  14 29 10](https://user-images.githubusercontent.com/7783861/220633939-85e8ced4-2261-49e3-abe9-841c021e3e92.png)

