### PR TITLE
Begynte å ta i `bruk digdir-krr-proxy` istedenfor `dkif`

### DIFF
--- a/nais/nais-preprod.yml
+++ b/nais/nais-preprod.yml
@@ -79,6 +79,10 @@ spec:
       value: https://www.nav.no
     - name: DKIF_SERVICE_URL
       value: {{ soknad-fss-proxy }}/digital-kontaktinformasjon/DigitalKontaktinformasjon/v1
+    - name: DIGDIR_KRR_PROXY_URL
+      value: http://digdir-krr-proxy.team-rocket
+    - name: DIGDIR_KRR_PROXY_AUDIENCE
+      value: dev-gcp:team-rocket:digdir-krr-proxy
     - name: ETTERSENDING_ANTALL_DAGER
       value: "70"
     - name: KODEVERK_SERVICE_URL

--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -77,6 +77,10 @@ spec:
       value: https://tjenester.nav.no/utbetalingsoversikt/
     - name: DKIF_SERVICE_URL
       value: {{ soknad-fss-proxy }}/digital-kontaktinformasjon/DigitalKontaktinformasjon/v1
+    - name: DIGDIR_KRR_PROXY_URL
+      value: http://digdir-krr-proxy.team-rocket
+    - name: DIGDIR_KRR_PROXY_AUDIENCE
+      value: prod-gcp:team-rocket:digdir-krr-proxy
     - name: ETTERSENDING_ANTALL_DAGER
       value: "70"
     - name: KODEVERK_SERVICE_URL

--- a/sendsoknad-boot/src/main/resources/application.yaml
+++ b/sendsoknad-boot/src/main/resources/application.yaml
@@ -187,3 +187,12 @@ no.nav.security.jwt:
                 client-auth-method: private_key_jwt
             token-exchange:
                 audience: ${SOKNAD_FSS_PROXY_AUDIENCE}
+        digdir-krr-proxy-tokenx:
+            well-known-url: ${TOKEN_X_WELL_KNOWN_URL}
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+                client-id: ${TOKEN_X_CLIENT_ID}
+                client-jwk: ${TOKEN_X_PRIVATE_JWK}
+                client-auth-method: private_key_jwt
+            token-exchange:
+                audience: ${DIGDIR_KRR_PROXY_AUDIENCE}

--- a/sendsoknad-consumer/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/ConsumerConfig.java
+++ b/sendsoknad-consumer/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/ConsumerConfig.java
@@ -5,10 +5,22 @@ import no.nav.sbl.dialogarena.soknadinnsending.consumer.person.PersonService;
 import no.nav.sbl.dialogarena.soknadinnsending.consumer.personalia.PersonaliaFletter;
 import no.nav.sbl.dialogarena.soknadinnsending.consumer.personinfo.PersonInfoService;
 import no.nav.sbl.dialogarena.soknadinnsending.consumer.wsconfig.*;
+import no.nav.security.token.support.client.core.ClientProperties;
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService;
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.DigitalKontaktinformasjonV1;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
 
 import static java.lang.System.setProperty;
 
@@ -42,5 +54,30 @@ public class ConsumerConfig {
             SakOgAktivitetWSConfig.class
     })
     public static class WsServices {
+    }
+
+    @Bean("digdirKrrProxyRestTemplate")
+    RestTemplate digdirKrrProxyRestTemplate(
+            ClientConfigurationProperties clientConfigurationProperties,
+            OAuth2AccessTokenService oAuth2AccessTokenService,
+            @Value("${DIGDIR_KRR_PROXY_URL}") String digdirKrrProxyBaseUrl,
+            RestTemplateBuilder restTemplateBuilder) {
+        var oauth2ClientProperties = clientConfigurationProperties.getRegistration().get("digdir-krr-proxy-tokenx");
+        return restTemplateBuilder
+                .rootUri(digdirKrrProxyBaseUrl)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .additionalInterceptors(createOAuth2Interceptor(oAuth2AccessTokenService, oauth2ClientProperties))
+                .build();
+    }
+
+    private ClientHttpRequestInterceptor createOAuth2Interceptor(
+            OAuth2AccessTokenService oAuth2AccessTokenService,
+            ClientProperties oauth2ClientProperties) {
+
+        return (request, body, execution) -> {
+            var accessTokenResponse = oAuth2AccessTokenService.getAccessToken(oauth2ClientProperties);
+            request.getHeaders().setBearerAuth(accessTokenResponse.getAccessToken());
+            return execution.execute(request, body);
+        };
     }
 }

--- a/sendsoknad-consumer/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/PersonaliaFletter.java
+++ b/sendsoknad-consumer/src/main/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/PersonaliaFletter.java
@@ -19,8 +19,6 @@ import no.nav.tjeneste.virksomhet.brukerprofil.v1.informasjon.XMLBankkontoUtland
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.informasjon.XMLBruker;
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.meldinger.XMLHentKontaktinformasjonOgPreferanserRequest;
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.meldinger.XMLHentKontaktinformasjonOgPreferanserResponse;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSKontaktinformasjon;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonResponse;
 import no.nav.tjeneste.virksomhet.person.v1.informasjon.Diskresjonskoder;
 import no.nav.tjeneste.virksomhet.person.v1.informasjon.Person;
 import no.nav.tjeneste.virksomhet.person.v1.informasjon.Statsborgerskap;
@@ -92,7 +90,7 @@ public class PersonaliaFletter {
         Diskresjonskoder diskresjonskode = kjerneinformasjonResponse.getPerson().getDiskresjonskode();
         String diskresjonskodeString = diskresjonskode == null ? null : diskresjonskode.getValue();
 
-        WSHentDigitalKontaktinformasjonResponse dkifResponse = epostService.hentInfoFraDKIF(fodselsnummer);
+        EpostService.DigitalKontaktinfo digitalKontaktinfo = epostService.hentDigitalKontaktinfo(fodselsnummer);
 
         return PersonaliaBuilder.
                 with()
@@ -104,8 +102,8 @@ public class PersonaliaFletter {
                 .withFornavn(finnFornavn(xmlBruker).trim())
                 .withMellomnavn(finnMellomNavn(xmlBruker).trim())
                 .withEtternavn(finnEtterNavn(xmlBruker))
-                .epost(finnEpost(dkifResponse))
-                .mobiltelefon(finnMobiltelefonnummer(dkifResponse))
+                .epost(digitalKontaktinfo.epostadresse())
+                .mobiltelefon(digitalKontaktinfo.mobiltelefonnummer())
                 .statsborgerskap(finnStatsborgerskap(xmlPerson))
                 .kjonn(finnKjonn(xmlBruker))
                 .gjeldendeAdresse(finnGjeldendeAdresse(xmlBruker, kodeverk))
@@ -179,21 +177,6 @@ public class PersonaliaFletter {
     private static LocalDate finnFodselsdato(Person person) {
         return new LocalDate(person.getFoedselsdato().getFoedselsdato().toGregorianCalendar());
     }
-
-    private static String finnMobiltelefonnummer(WSHentDigitalKontaktinformasjonResponse dkifResponse) {
-        WSKontaktinformasjon digitalKontaktinformasjon = dkifResponse.getDigitalKontaktinformasjon();
-        if (digitalKontaktinformasjon == null || digitalKontaktinformasjon.getMobiltelefonnummer() == null) {
-            return "";
-        }
-        return digitalKontaktinformasjon.getMobiltelefonnummer().getValue();
-    }
-    
-    private static String finnEpost(WSHentDigitalKontaktinformasjonResponse dkifResponse) {
-        WSKontaktinformasjon digitalKontaktinformasjon = dkifResponse.getDigitalKontaktinformasjon();
-        if (digitalKontaktinformasjon == null || digitalKontaktinformasjon.getEpostadresse() == null) {
-            return "";
-        }
-        return digitalKontaktinformasjon.getEpostadresse().getValue();    }
 
     private static String finnFnr(XMLBruker xmlBruker) {
         return xmlBruker.getIdent().getIdent();

--- a/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/EpostServiceTest.java
+++ b/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/EpostServiceTest.java
@@ -8,12 +8,12 @@ import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSKon
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSMobiltelefonnummer;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonRequest;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonResponse;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.*;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -26,7 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@RunWith(value = MockitoJUnitRunner.class)
 public class EpostServiceTest {
 
     @InjectMocks
@@ -39,7 +39,7 @@ public class EpostServiceTest {
     private RestTemplate restTemplate;
 
     @Test
-    void sendsCorrectRequestToDigdirKrrProxy() {
+    public void sendsCorrectRequestToDigdirKrrProxy() {
         String fnr = "12345612345";
 
         when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
@@ -57,7 +57,7 @@ public class EpostServiceTest {
     }
 
     @Test
-    void returnsResponseFromDigdirKrrProxyOnSuccess() {
+    public void returnsResponseFromDigdirKrrProxyOnSuccess() {
         String fnr = "12345612345";
 
         var digdirKrrProxyResponse = new EpostService.DigitalKontaktinfo("test@test.no", "12345678");
@@ -71,7 +71,7 @@ public class EpostServiceTest {
     }
 
     @Test
-    void returnsEmptyResponseFromDigdirKrrProxyWhenNoEpostOrMobil() {
+    public void returnsEmptyResponseFromDigdirKrrProxyWhenNoEpostOrMobil() {
         String fnr = "12345612345";
 
         var digdirKrrProxyResponse = new EpostService.DigitalKontaktinfo(null, null);
@@ -85,7 +85,7 @@ public class EpostServiceTest {
     }
 
     @Test
-    void returnsResponseFromDkifOnFailure() throws Exception {
+    public void returnsResponseFromDkifOnFailure() throws Exception {
         String fnr = "12345612345";
 
         when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
@@ -105,7 +105,7 @@ public class EpostServiceTest {
     }
 
     @Test
-    void returnsEmptyDigitalKontaktinfoOnFailure() throws Exception {
+    public void returnsEmptyDigitalKontaktinfoOnFailure() throws Exception {
         String fnr = "12345612345";
 
         when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))

--- a/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/EpostServiceTest.java
+++ b/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/EpostServiceTest.java
@@ -2,41 +2,121 @@ package no.nav.sbl.dialogarena.soknadinnsending.consumer.personalia;
 
 import no.nav.sbl.dialogarena.soknadinnsending.consumer.person.EpostService;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.DigitalKontaktinformasjonV1;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonKontaktinformasjonIkkeFunnet;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonPersonIkkeFunnet;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonSikkerhetsbegrensing;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSEpostadresse;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSKontaktinformasjon;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSMobiltelefonnummer;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonRequest;
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
-import static org.junit.Assert.assertNull;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
-@RunWith(value = MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EpostServiceTest {
 
     @InjectMocks
     private EpostService epostService;
 
-
     @Mock
     private DigitalKontaktinformasjonV1 dkif;
 
+    @Mock
+    private RestTemplate restTemplate;
+
     @Test
-    public void returnererTomEpostHvisDKIFErNede() throws HentDigitalKontaktinformasjonKontaktinformasjonIkkeFunnet, HentDigitalKontaktinformasjonSikkerhetsbegrensing, HentDigitalKontaktinformasjonPersonIkkeFunnet {
+    void sendsCorrectRequestToDigdirKrrProxy() {
         String fnr = "12345612345";
-        when(dkif.hentDigitalKontaktinformasjon(any(WSHentDigitalKontaktinformasjonRequest.class))).thenThrow(new HentDigitalKontaktinformasjonKontaktinformasjonIkkeFunnet());
 
-        WSHentDigitalKontaktinformasjonResponse response = epostService.hentInfoFraDKIF(fnr);
-        WSKontaktinformasjon kontaktinformasjon = response.getDigitalKontaktinformasjon();
+        when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
+                .thenReturn(new ResponseEntity<>(new EpostService.DigitalKontaktinfo("", ""), HttpStatus.OK));
 
-        assertNull(kontaktinformasjon.getEpostadresse());
+        epostService.hentDigitalKontaktinfo(fnr);
+
+        var requestEntityCaptor = ArgumentCaptor.forClass(RequestEntity.UriTemplateRequestEntity.class);
+        verify(restTemplate).exchange(requestEntityCaptor.capture(), eq(EpostService.DigitalKontaktinfo.class));
+        assertThat(requestEntityCaptor.getValue().getUriTemplate()).isEqualTo("/rest/v1/person");
+        assertThat(requestEntityCaptor.getValue().getMethod()).isEqualTo(HttpMethod.GET);
+        assertThat(requestEntityCaptor.getValue().getHeaders()).containsEntry("Nav-Personident", List.of(fnr));
+        assertThat(requestEntityCaptor.getValue().getHeaders()).containsKey("Nav-Call-Id");
+        assertThat(requestEntityCaptor.getValue().getBody()).isNull();
+    }
+
+    @Test
+    void returnsResponseFromDigdirKrrProxyOnSuccess() {
+        String fnr = "12345612345";
+
+        var digdirKrrProxyResponse = new EpostService.DigitalKontaktinfo("test@test.no", "12345678");
+        when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
+                .thenReturn(new ResponseEntity<>(digdirKrrProxyResponse, HttpStatus.OK));
+
+        EpostService.DigitalKontaktinfo result = epostService.hentDigitalKontaktinfo(fnr);
+
+        assertThat(result.epostadresse()).isEqualTo("test@test.no");
+        assertThat(result.mobiltelefonnummer()).isEqualTo("12345678");
+    }
+
+    @Test
+    void returnsEmptyResponseFromDigdirKrrProxyWhenNoEpostOrMobil() {
+        String fnr = "12345612345";
+
+        var digdirKrrProxyResponse = new EpostService.DigitalKontaktinfo(null, null);
+        when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
+                .thenReturn(new ResponseEntity<>(digdirKrrProxyResponse, HttpStatus.OK));
+
+        EpostService.DigitalKontaktinfo result = epostService.hentDigitalKontaktinfo(fnr);
+
+        assertThat(result.epostadresse()).isEmpty();
+        assertThat(result.mobiltelefonnummer()).isEmpty();
+    }
+
+    @Test
+    void returnsResponseFromDkifOnFailure() throws Exception {
+        String fnr = "12345612345";
+
+        when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", new HttpHeaders(), null, null));
+
+        var dkifResponse = new WSHentDigitalKontaktinformasjonResponse()
+                .withDigitalKontaktinformasjon(new WSKontaktinformasjon()
+                        .withEpostadresse(new WSEpostadresse().withValue("test@test.no"))
+                        .withMobiltelefonnummer(new WSMobiltelefonnummer().withValue("12345678")));
+        when(dkif.hentDigitalKontaktinformasjon(any(WSHentDigitalKontaktinformasjonRequest.class)))
+                .thenReturn(dkifResponse);
+
+        EpostService.DigitalKontaktinfo result = epostService.hentDigitalKontaktinfo(fnr);
+
+        assertThat(result.epostadresse()).isEqualTo("test@test.no");
+        assertThat(result.mobiltelefonnummer()).isEqualTo("12345678");
+    }
+
+    @Test
+    void returnsEmptyDigitalKontaktinfoOnFailure() throws Exception {
+        String fnr = "12345612345";
+
+        when(restTemplate.exchange(any(RequestEntity.class), eq(EpostService.DigitalKontaktinfo.class)))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request", new HttpHeaders(), null, null));
+
+        when(dkif.hentDigitalKontaktinformasjon(any(WSHentDigitalKontaktinformasjonRequest.class)))
+                .thenThrow(new HentDigitalKontaktinformasjonSikkerhetsbegrensing());
+
+        EpostService.DigitalKontaktinfo result = epostService.hentDigitalKontaktinfo(fnr);
+
+        assertThat(result.epostadresse()).isEmpty();
+        assertThat(result.mobiltelefonnummer()).isEmpty();
     }
 }

--- a/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/PersonaliaFletterTest.java
+++ b/sendsoknad-consumer/src/test/java/no/nav/sbl/dialogarena/soknadinnsending/consumer/personalia/PersonaliaFletterTest.java
@@ -13,10 +13,6 @@ import no.nav.tjeneste.virksomhet.brukerprofil.v1.HentKontaktinformasjonOgPrefer
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.informasjon.*;
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.meldinger.XMLHentKontaktinformasjonOgPreferanserRequest;
 import no.nav.tjeneste.virksomhet.brukerprofil.v1.meldinger.XMLHentKontaktinformasjonOgPreferanserResponse;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSEpostadresse;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSKontaktinformasjon;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSMobiltelefonnummer;
-import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.meldinger.WSHentDigitalKontaktinformasjonResponse;
 import no.nav.tjeneste.virksomhet.person.v1.informasjon.*;
 import no.nav.tjeneste.virksomhet.person.v1.meldinger.HentKjerneinformasjonResponse;
 import org.joda.time.DateTime;
@@ -127,10 +123,9 @@ public class PersonaliaFletterTest {
         preferanserResponse.setPerson(xmlBruker);
         when(brukerProfilMock.hentKontaktinformasjonOgPreferanser(any(XMLHentKontaktinformasjonOgPreferanserRequest.class))).thenReturn(preferanserResponse);
 
-        WSHentDigitalKontaktinformasjonResponse digitalKontaktinformasjonResponse = new WSHentDigitalKontaktinformasjonResponse();
-        digitalKontaktinformasjonResponse.setDigitalKontaktinformasjon(genererDigitalKontaktinformasjonMedEpost());
+        EpostService.DigitalKontaktinfo digitalKontaktinformasjonResponse = genererDigitalKontaktinformasjonMedEpost();
 
-        when(epostMock.hentInfoFraDKIF(any(String.class))).thenReturn(digitalKontaktinformasjonResponse);
+        when(epostMock.hentDigitalKontaktinfo(any(String.class))).thenReturn(digitalKontaktinformasjonResponse);
     }
 
     @Test
@@ -154,9 +149,8 @@ public class PersonaliaFletterTest {
         preferanserResponse.setPerson(xmlBruker);
         when(brukerProfilMock.hentKontaktinformasjonOgPreferanser(any(XMLHentKontaktinformasjonOgPreferanserRequest.class))).thenReturn(preferanserResponse);
 
-        WSHentDigitalKontaktinformasjonResponse digitalKontaktinformasjonResponse = new WSHentDigitalKontaktinformasjonResponse();
-        digitalKontaktinformasjonResponse.setDigitalKontaktinformasjon(genererDigitalKontaktinformasjonUtenEpost());
-        when(epostMock.hentInfoFraDKIF(any(String.class))).thenReturn(digitalKontaktinformasjonResponse);
+        EpostService.DigitalKontaktinfo digitalKontaktinformasjonResponse = genererDigitalKontaktinformasjonUtenEpost();
+        when(epostMock.hentDigitalKontaktinfo(any(String.class))).thenReturn(digitalKontaktinformasjonResponse);
 
         mockGyldigPerson();
 
@@ -587,18 +581,11 @@ public class PersonaliaFletterTest {
         return foedselsdato;
     }
 
-    private static WSKontaktinformasjon genererDigitalKontaktinformasjonMedEpost() {
-        return new WSKontaktinformasjon()
-                .withPersonident(IDENT)
-                .withEpostadresse(new WSEpostadresse().withValue("test@test.com"))
-                .withMobiltelefonnummer(new WSMobiltelefonnummer().withValue("12345678"))
-                .withReservasjon("");
+    private static EpostService.DigitalKontaktinfo genererDigitalKontaktinformasjonMedEpost() {
+        return new EpostService.DigitalKontaktinfo("test@test.com", "12345678");
     }
 
-    private static WSKontaktinformasjon genererDigitalKontaktinformasjonUtenEpost() {
-        return new WSKontaktinformasjon()
-                .withPersonident(IDENT)
-                .withMobiltelefonnummer(new WSMobiltelefonnummer().withValue("12345678"))
-                .withReservasjon("");
+    private static EpostService.DigitalKontaktinfo genererDigitalKontaktinformasjonUtenEpost() {
+        return new EpostService.DigitalKontaktinfo("", "12345678");
     }
 }

--- a/sendsoknad-web/src/main/java/no/nav/sbl/dialogarena/config/SikkerhetsConfig.java
+++ b/sendsoknad-web/src/main/java/no/nav/sbl/dialogarena/config/SikkerhetsConfig.java
@@ -115,4 +115,12 @@ public class SikkerhetsConfig {
         var clientProperties = clientConfigurationProperties.getRegistration().get("soknad-fss-proxy-tokenx");
         return new TokenService(clientProperties, oAuth2AccessTokenService);
     }
+
+    @Bean("DigdirKrrProxyTokenX")
+    TokenService digdirKrrProxyTokenXTokenService(
+            ClientConfigurationProperties clientConfigurationProperties,
+            OAuth2AccessTokenService oAuth2AccessTokenService) {
+        var clientProperties = clientConfigurationProperties.getRegistration().get("digdir-krr-proxy-tokenx");
+        return new TokenService(clientProperties, oAuth2AccessTokenService);
+    }
 }

--- a/sendsoknad-web/src/main/java/no/nav/sbl/dialogarena/config/SikkerhetsConfig.java
+++ b/sendsoknad-web/src/main/java/no/nav/sbl/dialogarena/config/SikkerhetsConfig.java
@@ -115,12 +115,4 @@ public class SikkerhetsConfig {
         var clientProperties = clientConfigurationProperties.getRegistration().get("soknad-fss-proxy-tokenx");
         return new TokenService(clientProperties, oAuth2AccessTokenService);
     }
-
-    @Bean("DigdirKrrProxyTokenX")
-    TokenService digdirKrrProxyTokenXTokenService(
-            ClientConfigurationProperties clientConfigurationProperties,
-            OAuth2AccessTokenService oAuth2AccessTokenService) {
-        var clientProperties = clientConfigurationProperties.getRegistration().get("digdir-krr-proxy-tokenx");
-        return new TokenService(clientProperties, oAuth2AccessTokenService);
-    }
 }


### PR DESCRIPTION
Jeg jobber med å få så mange konsumenter bort fra `dkif` som mulig, ettersom den er på listen over applikasjoner som skal dø, og jeg tenkte jeg kunne prøve meg på en PR til dere. Forhåpentligvis er den mer til nytte enn til bry 😄 

Den nye applikasjonen som dere kan bruke heter `digdir-krr-proxy` og den befinner seg i GCP, så dere slipper å gå via noen proxy. Jeg håper jeg har satt opp tokenutveksling og slikt riktig, for jeg har egentlig kodet litt i blinde basert på hva jeg kunne skjønne ut ifra deres eksisterende oppsett!

Det vil være jeg har glemt noe (f. eks en `Pingable` implementasjon, andre typer automatiske tester enn enhetstester, etc), men da får dere bare peke meg i riktig retning, så kan jeg prøve å se på det 😃 

Dette vil være steg 1 i migreringsprosessen, ettersom koden for å kalle `dkif` fortsatt ligger der, og benyttes dersom kallet til `digdir-krr-proxy` feiler. Steg 2 vil da gå ut på å fjerne denne koden.

Forresten, _ikke_ merge denne PR'en før vi har fått på plass det byråkratiske rundt nye konsumenter av `digdir-krr-proxy`. Jeg må nemlig også pre-authorize deres applikasjon før dere kan begynne å gjøre kall dit. Det kan vi få til hvis dere [oppretter et issue med detaljene her](https://github.com/navikt/digdir-krr/issues/new?assignees=&labels=app%3A+digdir-krr-proxy%2C+type%3A+pre-authorize&projects=&template=pre-authorize-applikasjon.md&title=Pre-authorize+%3Capp%3E).

Ellers er det bare å ta kontakt om det skulle være noe. Jeg er godt kjent med både `dkif` og med `digdir-krr-proxy`, så jeg kan svare på det meste der, hvertfall.

PS: Håper dette bygger grønt, hvis ikke får jeg se på det til uka.